### PR TITLE
Publish: Use new workfiles API to increment current workfile

### DIFF
--- a/client/ayon_celaction/plugins/publish/integrate_version_up.py
+++ b/client/ayon_celaction/plugins/publish/integrate_version_up.py
@@ -3,20 +3,54 @@ import shutil
 import pyblish.api
 
 from ayon_core.lib import version_up
+try:
+    from ayon_core.pipeline.workfile import (
+        save_workfile_info,
+        find_workfile_rootless_path,
+    )
+except ImportError:
+    save_workfile_info = None
 
 
 class VersionUpScene(pyblish.api.ContextPlugin):
     order = pyblish.api.IntegratorOrder + 0.5
-    label = 'Version Up Scene'
-    families = ['workfile']
+    label = "Version Up Scene"
+    families = ["workfile"]
     optional = True
     active = True
 
     def process(self, context):
-        current_file = context.data.get('currentFile')
+        current_file = context.data["currentFile"]
         v_up = version_up(current_file)
-        self.log.debug('Current file is: {}'.format(current_file))
-        self.log.debug('Version up: {}'.format(v_up))
+        self.log.debug(f"Current file is: {current_file}")
+        self.log.debug(f"Version up: {v_up}")
 
         shutil.copy2(current_file, v_up)
-        self.log.info('Scene saved into new version: {}'.format(v_up))
+
+        # Create workfile information in AYON server
+        if save_workfile_info is not None:
+            host_name = context.data["hostName"]
+            anatomy = context.data["anatomy"]
+            project_name = context.data["projectName"]
+            project_settings = context.data["project_settings"]
+            project_entity = context.data["projectEntity"]
+            folder_entity = context.data["folderEntity"]
+            task_entity = context.data["taskEntity"]
+            rootless_path = find_workfile_rootless_path(
+                v_up,
+                project_name,
+                folder_entity,
+                task_entity,
+                host_name,
+                project_entity=project_entity,
+                project_settings=project_settings,
+                anatomy=anatomy,
+            )
+            save_workfile_info(
+                project_name,
+                task_entity["id"],
+                rootless_path,
+                host_name,
+            )
+
+        self.log.info(f"Scene saved into new version: {v_up}")


### PR DESCRIPTION
## Changelog Description

When incrementing the workfile during publish, use the new context-based workfile API so that the current author information is stored with the saved file.

## Additional review information

Test with ayon-core 1.5.0 (and also backwards compatibility against older releases)

## Testing notes:

1. Publishing should work
2. Workfile should be incremented
3. Workfile should show the author of the publish 
4. Workfile should have 'artist note' set: "Incremented by publishing."
5. Publishing should also still work and increment (the old way) with older ayon-core.
