### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_celaction/plugins/publish/collect_celaction_instances.py
+++ b/client/ayon_celaction/plugins/publish/collect_celaction_instances.py
@@ -41,6 +41,7 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
 
         # workfile instance
         product_type = "workfile"
+        product_base_type = "workfile"
         product_name = product_type + task.capitalize()
         # Create instance
         instance = context.create_instance(product_name)
@@ -50,8 +51,9 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
             "label": scene_file,
             "productName": product_name,
             "productType": product_type,
-            "family": product_type,
-            "families": [product_type],
+            "productBaseType": product_base_type,
+            "family": product_base_type,
+            "families": [product_base_type],
             "representations": []
         })
 
@@ -73,6 +75,7 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
         # render instance
         product_name = f"render{task}Main"
         product_type = "render.farm"
+        product_base_type = "render.farm"
         instance = context.create_instance(name=product_name)
         # getting instance state
         instance.data["publish"] = True
@@ -81,8 +84,9 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
         instance.data.update({
             "label": "{} - farm".format(product_name),
             "productType": product_type,
-            "family": product_type,
-            "families": [product_type],
+            "productBaseType": product_base_type,
+            "family": product_base_type,
+            "families": [product_base_type],
             "productName": product_name
         })
 

--- a/client/ayon_celaction/plugins/publish/collect_render_path.py
+++ b/client/ayon_celaction/plugins/publish/collect_render_path.py
@@ -22,9 +22,10 @@ class CollectRenderPath(pyblish.api.InstancePlugin):
         anatomy_data = copy.deepcopy(instance.data["anatomyData"])
         padding = anatomy.templates_obj.frame_padding
         product_type = "render"
+        product_base_type = "render"
         anatomy_data.update({
             "frame": f"%0{padding}d",
-            "family": product_type,
+            "family": product_base_type,
             "representation": self.output_extension,
             "ext": self.output_extension
         })


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to collectors (since there are no creators) and it is changing the use of `product_type` to `product_base_type` in case of families.

## Testing notes:
Everything should work as before.
