### PR TITLE
Chore: Use product base type

### DIFF
--- a/client/ayon_celaction/plugins/publish/collect_celaction_instances.py
+++ b/client/ayon_celaction/plugins/publish/collect_celaction_instances.py
@@ -79,6 +79,7 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
         # add folderEntity data into instance
         instance.data.update({
             "publish": True,
+            "farm": True,
             "label": f"{product_name} - farm",
             "productType": product_base_type,
             "productBaseType": product_base_type,

--- a/client/ayon_celaction/plugins/publish/collect_celaction_instances.py
+++ b/client/ayon_celaction/plugins/publish/collect_celaction_instances.py
@@ -45,6 +45,14 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
         # Create instance
         instance = context.create_instance(product_name)
 
+        # creating representation
+        representation = {
+            "name": "scn",
+            "ext": "scn",
+            "files": scene_file,
+            "stagingDir": staging_dir,
+        }
+
         # creating instance data
         instance.data.update({
             "label": scene_file,
@@ -53,21 +61,12 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
             "productBaseType": product_base_type,
             "family": product_base_type,
             "families": [product_base_type],
-            "representations": []
+            "representations": [representation]
         })
 
         # adding basic script data
         instance.data.update(shared_instance_data)
 
-        # creating representation
-        representation = {
-            'name': 'scn',
-            'ext': 'scn',
-            'files': scene_file,
-            "stagingDir": staging_dir,
-        }
-
-        instance.data["representations"].append(representation)
 
         self.log.info('Publishing Celaction workfile')
 

--- a/client/ayon_celaction/plugins/publish/collect_celaction_instances.py
+++ b/client/ayon_celaction/plugins/publish/collect_celaction_instances.py
@@ -40,9 +40,8 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
             shared_instance_data.update(celaction_kwargs)
 
         # workfile instance
-        product_type = "workfile"
         product_base_type = "workfile"
-        product_name = product_type + task.capitalize()
+        product_name = product_base_type + task.capitalize()
         # Create instance
         instance = context.create_instance(product_name)
 
@@ -50,7 +49,7 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
         instance.data.update({
             "label": scene_file,
             "productName": product_name,
-            "productType": product_type,
+            "productType": product_base_type,
             "productBaseType": product_base_type,
             "family": product_base_type,
             "families": [product_base_type],
@@ -74,20 +73,19 @@ class CollectCelactionInstances(pyblish.api.ContextPlugin):
 
         # render instance
         product_name = f"render{task}Main"
-        product_type = "render.farm"
-        product_base_type = "render.farm"
+        product_base_type = "render"
         instance = context.create_instance(name=product_name)
-        # getting instance state
-        instance.data["publish"] = True
 
         # add folderEntity data into instance
         instance.data.update({
-            "label": "{} - farm".format(product_name),
-            "productType": product_type,
+            "publish": True,
+            "label": f"{product_name} - farm",
+            "productType": product_base_type,
             "productBaseType": product_base_type,
             "family": product_base_type,
-            "families": [product_base_type],
-            "productName": product_name
+            "families": [product_base_type, "render.farm"],
+            "productName": product_name,
+            "representations": [],
         })
 
         # adding basic script data

--- a/client/ayon_celaction/plugins/publish/collect_render_path.py
+++ b/client/ayon_celaction/plugins/publish/collect_render_path.py
@@ -21,7 +21,6 @@ class CollectRenderPath(pyblish.api.InstancePlugin):
         anatomy = instance.context.data["anatomy"]
         anatomy_data = copy.deepcopy(instance.data["anatomyData"])
         padding = anatomy.templates_obj.frame_padding
-        product_type = "render"
         product_base_type = "render"
         anatomy_data.update({
             "frame": f"%0{padding}d",
@@ -29,7 +28,8 @@ class CollectRenderPath(pyblish.api.InstancePlugin):
             "representation": self.output_extension,
             "ext": self.output_extension
         })
-        anatomy_data["product"]["type"] = product_type
+        anatomy_data["product"]["type"] = product_base_type
+        anatomy_data["product"]["basetype"] = product_base_type
 
         # get anatomy rendering keys
         r_anatomy_key = self.anatomy_template_key_render_files

--- a/package.py
+++ b/package.py
@@ -7,7 +7,7 @@ project_can_override_addon_version = True
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">0.3.2",
+    "core": ">=1.8.0",
 }
 ayon_compatible_addons = {
     "applications": ">=0.2.0",


### PR DESCRIPTION
## Changelog Description
This is an attempt to fully use product base types in celaction.

## Additional review information
Get rid of product type from most of the logic and use only product base type. Another change related to that is that `render.farm` is not used on instance as family, instead is used `render` and `render.farm` is added to families. Which "should" work but I didn't validate it and as far as I know we don't have celaction to validate it.

## Testing notes:
1. Technically nothing should change from a perspective of artist.
